### PR TITLE
Add NSLocalNetworkUsageDescription to Info.plist

### DIFF
--- a/XRViewer/Resources/Info.plist
+++ b/XRViewer/Resources/Info.plist
@@ -44,6 +44,8 @@
 	<string>When a web page uses WebXR, video from the camera will be displayed in the background and used to track device motion in 3D. You will be asked for further permission before a web page may access the video or use the Truedepth camera for face tracking.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Location is used to enable the Web Geolocation API. You will be asked for permission before a web page can access your location.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Local network access is required to load websites on your local network e.g. 192.168.1.5 for development purposes.</string>
 	<key>NSSupportsSuddenTermination</key>
 	<false/>
 	<key>UIAppFonts</key>


### PR DESCRIPTION
As per: https://developer.apple.com/documentation/bundleresources/information_property_list/nslocalnetworkusagedescription

Resolves #189.

I have literally never done any iOS development before so I don't know if this is right. I'm just making my best guess based of what google told me about adding this permission.